### PR TITLE
allow non-letters in snake case

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,8 +52,8 @@ module.exports = (opts = {}) => {
       if (!EASING_NAME.test(name)) {
         throw new Error(
           `Custom easing ${name} has bad name. ` +
-            'Name should start from `ease` and contain ' +
-            'only letters and dashes'
+            'Name should start with `ease` and contain ' +
+            'only letters, numbers, underscore and dashes'
         )
       }
       locals[name] = opts.easings[name]

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function toSnake (str) {
 }
 
 function toCamel (str) {
-  return str.replace(/-[a-z]/g, letter => {
+  return str.replace(/-(.)/g, letter => {
     return letter[1].toUpperCase()
   })
 }

--- a/index.test.js
+++ b/index.test.js
@@ -77,6 +77,24 @@ test('checks custom easings name', () => {
   }, /^Custom easing my has bad name/)
 })
 
+test('checks another custom easings name with whitespace', () => {
+  throws(() => {
+    plugin({ easings: { 'ease- In': '1' } })
+  }, /^Custom easing ease- In has bad name/)
+})
+
+test('add custom easings with numbers in name', async () => {
+  await run('a { transition: ease4-you, ease4You }', 'a { transition: 1, 1 }', {
+    easings: { ease4You: '1' }
+  })
+})
+
+test('add custom easings with numbers in snake name', async () => {
+  await run('a { transition: ease-4-you, ease4You }', 'a { transition: 1, 1 }', {
+    easings: { 'ease-4-you': '1' }
+  })
+})
+
 test('exports easings', () => {
   equal(plugin.easings.easeInSine, 'cubic-bezier(0.12, 0, 0.39, 0)')
 })


### PR DESCRIPTION
the current code toCamel() converts "go-2-town" to "go-2Town".  This fix converts it to "go2Town".  It is also slightly more efficient because it only captures the next character instead of matching lowercase letters.